### PR TITLE
Update io.github.peazip.PeaZip.yml

### DIFF
--- a/io.github.peazip.PeaZip.yml
+++ b/io.github.peazip.PeaZip.yml
@@ -8,7 +8,8 @@ rename-icon: peazip
 rename-desktop-file: peazip.desktop
 command: peazip
 finish-args:
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --device=dri
   - --share=ipc
   - --filesystem=host


### PR DESCRIPTION
Wayland, fallback X11, Qt5
Qt6 still not building on Flatpak environment as per previous attempts.