### PR TITLE
Switch to QT6 build

### DIFF
--- a/io.github.peazip.PeaZip.yml
+++ b/io.github.peazip.PeaZip.yml
@@ -1,6 +1,6 @@
 app-id: io.github.peazip.PeaZip
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: "6.8"
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.freepascal
@@ -33,7 +33,7 @@ build-options:
 modules:
 #  - shared-modules/gtk2/gtk2.json
 
-  - name: qt5pas
+  - name: qt6pas
     config-opts:
       - -after
       - target.path=/app/lib
@@ -41,7 +41,7 @@ modules:
     sources:
       - type: shell
         commands:
-          - cp -r /usr/lib/sdk/freepascal/share/lazarus/lcl/interfaces/qt5/cbindings/.
+          - cp -r /usr/lib/sdk/freepascal/share/lazarus/lcl/interfaces/qt6/cbindings/.
             .
 
   - name: peazip
@@ -50,7 +50,7 @@ modules:
       - |
         . /usr/lib/sdk/freepascal/enable.sh
         lazbuild --add-package dev/metadarkstyle/metadarkstyle.lpk
-        lazbuild --widgetset=qt5 --build-all --max-process-count=1 dev/project_pea.lpi dev/project_peach.lpi
+        lazbuild --widgetset=qt6 --build-all --max-process-count=1 dev/project_pea.lpi dev/project_peach.lpi
     post-install:
       # bin
       - mkdir -p $FLATPAK_DEST/bin


### PR DESCRIPTION
This enables the QT6 build. I'll be honest, I just saw #95 and saw, that the change of the SDK was forgotten, but it seems to work fine. I'm not sure what version of QT PeaZip is built for, but it installed fine with the newest 6.8 :)